### PR TITLE
feat: add support for #[builder(default)] attribute without expression

### DIFF
--- a/typesafe_builder_derive/src/derive_builder/generate_setter_methods.rs
+++ b/typesafe_builder_derive/src/derive_builder/generate_setter_methods.rs
@@ -1,8 +1,11 @@
-use crate::{derive_builder::extract_arg_type, input::Requirement};
+use crate::{
+    derive_builder::extract_arg_type,
+    input::{DefaultValue, Requirement},
+};
 use quote::quote;
 use syn::{Generics, Ident, Type};
 
-type FieldInfo = (Ident, Type, Requirement, Option<syn::Expr>, bool);
+type FieldInfo = (Ident, Type, Requirement, Option<DefaultValue>, bool);
 
 pub fn generate_setter_methods<'a>(
     field_infos: &'a [FieldInfo],

--- a/typesafe_builder_derive/tests/derive_builder.rs
+++ b/typesafe_builder_derive/tests/derive_builder.rs
@@ -271,3 +271,65 @@ fn into_value_success() {
     assert_eq!(user.name, "Alice");
     assert_eq!(user.address, Some("foo".to_string()));
 }
+
+#[test]
+fn bare_default_success() {
+    #[derive(Builder, PartialEq)]
+    struct Config {
+        #[builder(default)]
+        name: String,
+        #[builder(default)]
+        port: i32,
+        #[builder(default)]
+        enabled: bool,
+    }
+
+    let config = ConfigBuilder::new().build();
+    assert_eq!(config.name, String::default());
+    assert_eq!(config.port, i32::default());
+    assert_eq!(config.enabled, bool::default());
+
+    let config = ConfigBuilder::new()
+        .with_name("custom".to_string())
+        .with_port(8080)
+        .with_enabled(true)
+        .build();
+    assert_eq!(config.name, "custom");
+    assert_eq!(config.port, 8080);
+    assert_eq!(config.enabled, true);
+}
+
+#[test]
+fn mixed_default_and_expression_default() {
+    #[derive(Builder, PartialEq)]
+    struct Config {
+        #[builder(default)]
+        name: String,
+        #[builder(default = "42")]
+        port: i32,
+        #[builder(default = "vec![1, 2, 3]")]
+        numbers: Vec<i32>,
+    }
+
+    let config = ConfigBuilder::new().build();
+    assert_eq!(config.name, String::default());
+    assert_eq!(config.port, 42);
+    assert_eq!(config.numbers, vec![1, 2, 3]);
+}
+
+#[test]
+fn bare_default_with_custom_types() {
+    #[derive(PartialEq, Default, Debug)]
+    struct CustomType {
+        value: i32,
+    }
+
+    #[derive(Builder, PartialEq)]
+    struct Config {
+        #[builder(default)]
+        custom: CustomType,
+    }
+
+    let config = ConfigBuilder::new().build();
+    assert_eq!(config.custom, CustomType::default());
+}


### PR DESCRIPTION
## Summary
- Add support for bare `#[builder(default)]` attribute that uses `Default::default()`
- Maintain backward compatibility with existing `#[builder(default = "expression")]` syntax
- Implement `DefaultValue` enum to handle both cases

## Changes
- Created `DefaultValue` enum to distinguish between bare defaults and expression defaults
- Updated parser to recognize `#[builder(default)]` without value using `darling::FromMeta`
- Modified code generation to use `Default::default()` for bare attributes
- Added comprehensive test coverage for new functionality

## Test Plan
- All existing tests pass (17/17)
- Added tests for bare default attributes with various types
- Added tests for mixed usage of bare and expression defaults
- Verified compatibility with custom types implementing Default